### PR TITLE
Replace `Fn` with `FnOnce` in API

### DIFF
--- a/src/custom.rs
+++ b/src/custom.rs
@@ -5,7 +5,7 @@ use crate::{VM, ACTIVITY_GETTER, JNIEnv, JObject};
 
 pub fn with_activity_inner<F, R>(f: F) -> Option<R>
 where
-    F: for<'a, 'b, 'c, 'd> Fn(&'a mut JNIEnv<'b>, &'c JObject<'d>) -> R,
+    F: for<'a, 'b, 'c, 'd> FnOnce(&'a mut JNIEnv<'b>, &'c JObject<'d>) -> R,
 {
     let getter = ACTIVITY_GETTER.get()?;
     let (jni_env_opt, activity) = getter();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,7 +86,7 @@ pub unsafe fn set_activity_getter(f: ActivityGetterFn) -> Result<(), ActivityGet
 /// * If the current JNI environment cannot be obtained.
 pub fn with_activity<F, R>(f: F) -> Option<R>
 where
-    F: for<'a, 'b, 'c, 'd> Fn(&'a mut JNIEnv<'b>, &'c JObject<'d>) -> R,
+    F: for<'a, 'b, 'c, 'd> FnOnce(&'a mut JNIEnv<'b>, &'c JObject<'d>) -> R,
 {
     inner::with_activity_inner(f)
 }

--- a/src/makepad.rs
+++ b/src/makepad.rs
@@ -2,7 +2,7 @@ use makepad_android_state::{get_activity, get_java_vm};
 
 pub fn with_activity_inner<F, R>(f: F) -> Option<R>
 where
-    F: for<'a, 'b, 'c, 'd> Fn(&'a mut crate::JNIEnv<'b>, &'c crate::JObject<'d>) -> R,
+    F: for<'a, 'b, 'c, 'd> FnOnce(&'a mut crate::JNIEnv<'b>, &'c crate::JObject<'d>) -> R,
 {
     let jvm = unsafe { crate::JavaVM::from_raw(get_java_vm().cast()) }.ok()?;
     let mut jni_env = jvm.get_env().ok()?;

--- a/src/ndk_context.rs
+++ b/src/ndk_context.rs
@@ -11,7 +11,7 @@ use crate::{JavaVM, JNIEnv, JObject};
 
 pub fn with_activity_inner<F, R>(f: F) -> Option<R>
 where
-    F: for<'a, 'b, 'c, 'd> Fn(&'a mut JNIEnv<'b>, &'c JObject<'d>) -> R,
+    F: for<'a, 'b, 'c, 'd> FnOnce(&'a mut JNIEnv<'b>, &'c JObject<'d>) -> R,
 {
     let android_context = ndk_context::android_context();
     // SAFETY: we have no option but to trust the pointers from ndk-context.


### PR DESCRIPTION
Allows calling the API with a moving closure.